### PR TITLE
Add repeat option to timestamp task

### DIFF
--- a/sparkapp-client/src/test/java/org/springframework/cloud/task/sparkapp/client/SparkAppClientTaskApplicationTests.java
+++ b/sparkapp-client/src/test/java/org/springframework/cloud/task/sparkapp/client/SparkAppClientTaskApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @IntegrationTest({"app-name:pi",
 		"app-jar:dummy.jar",
 		"app-class:org.apache.spark.examples.JavaSparkPi",
-		"app-args:10"})
+		"app-args:10",
+		"spring.cloud.task.closecontext.enable:false"})
 public class SparkAppClientTaskApplicationTests {
 
 	@Test

--- a/sqoop-job/src/test/java/org/springframework/cloud/task/sqoop/job/SqoopToolJobApplicationTests.java
+++ b/sqoop-job/src/test/java/org/springframework/cloud/task/sqoop/job/SqoopToolJobApplicationTests.java
@@ -73,7 +73,8 @@ public abstract class SqoopToolJobApplicationTests {
 		System.setProperty("sqoop.test.dir", testDir);
 	}
 
-	@IntegrationTest({"spring.hadoop.fsUri=file:///",
+	@IntegrationTest({"spring.cloud.task.closecontext.enable:false",
+			"spring.hadoop.fsUri=file:///",
 			"spring.hadoop.config.mapreduce.framework.name=local",
 			"metastore-url=jdbc:hsqldb:hsql://localhost:${db.server.port}/test",
 			"metastore-username=sa",
@@ -97,7 +98,8 @@ public abstract class SqoopToolJobApplicationTests {
 		}
 	}
 
-	@IntegrationTest({"spring.hadoop.fsUri=file:///",
+	@IntegrationTest({"spring.cloud.task.closecontext.enable:false",
+			"spring.hadoop.fsUri=file:///",
 			"spring.hadoop.config.mapreduce.framework.name=local",
 			"metastore-url=jdbc:hsqldb:hsql://localhost:${db.server.port}/test",
 			"metastore-username=sa",
@@ -125,7 +127,8 @@ public abstract class SqoopToolJobApplicationTests {
 		}
 	}
 
-	@IntegrationTest({"spring.hadoop.fsUri=file:///",
+	@IntegrationTest({"spring.cloud.task.closecontext.enable:false",
+			"spring.hadoop.fsUri=file:///",
 			"spring.hadoop.config.mapreduce.framework.name=local",
 			"metastore-url=jdbc:hsqldb:hsql://localhost:${db.server.port}/test",
 			"metastore-username=sa",

--- a/sqoop-tool/src/test/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskApplicationTests.java
+++ b/sqoop-tool/src/test/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskApplicationTests.java
@@ -73,7 +73,8 @@ public abstract class SqoopToolTaskApplicationTests {
 		System.setProperty("sqoop.test.dir", testDir);
 	}
 
-	@IntegrationTest({"spring.hadoop.fsUri=file:///",
+	@IntegrationTest({"spring.cloud.task.closecontext.enable:false",
+			"spring.hadoop.fsUri=file:///",
 			"spring.hadoop.config.mapreduce.framework.name=local",
 			"connect=jdbc:hsqldb:hsql://localhost:${db.server.port}/test",
 			"username=sa",
@@ -98,7 +99,8 @@ public abstract class SqoopToolTaskApplicationTests {
 		}
 	}
 
-	@IntegrationTest({"spring.hadoop.fsUri=file:///",
+	@IntegrationTest({"spring.cloud.task.closecontext.enable:false",
+			"spring.hadoop.fsUri=file:///",
 			"spring.hadoop.config.mapreduce.framework.name=local",
 			"connect=jdbc:hsqldb:hsql://localhost:${db.server.port}/test",
 			"username=sa",

--- a/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TaskApplication.java
+++ b/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TaskApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,13 @@ public class TaskApplication {
 		@Override
 		public void run(String... strings) throws Exception {
 			DateFormat dateFormat = new SimpleDateFormat(config.getFormat());
-			logger.info(dateFormat.format(new Date()));
+			for (int i = 0; i < config.getRepeat(); i++) {
+				logger.info(dateFormat.format(new Date()));
+				if (config.getRepeat() > 1) {
+					logger.info("Sleeping 1 sec");
+					Thread.sleep(1000);
+				}
+			}
 		}
 	}
 }

--- a/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TimestampTaskProperties.java
+++ b/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TimestampTaskProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Glenn Renfro
+ * @author Janne Valkealahti
  */
 @ConfigurationProperties
 public class TimestampTaskProperties {
@@ -30,6 +31,12 @@ public class TimestampTaskProperties {
 	 */
 	private String format = "yyyy-MM-dd HH:mm:ss.SSS";
 
+	/**
+	 * How many times application repeats logging while waiting 1 sec between
+	 * each repeat, "1" by default.
+	 */
+	private int repeat = 1;
+
 	public String getFormat() {
 		Assert.hasText(format, "format must not be empty nor null");
 		return format;
@@ -37,5 +44,13 @@ public class TimestampTaskProperties {
 
 	public void setFormat(String format) {
 		this.format = format;
+	}
+
+	public int getRepeat() {
+		return repeat;
+	}
+
+	public void setRepeat(int repeat) {
+		this.repeat = repeat;
 	}
 }

--- a/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TaskApplicationTests.java
+++ b/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TaskApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,13 @@
 
 package org.springframework.cloud.task.timestamp;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.test.OutputCapture;
-import org.springframework.cloud.task.repository.TaskExplorer;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.data.domain.PageRequest;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
 
 /**
  * Verifies that the Task Application outputs the correct task log entries.
@@ -42,19 +38,36 @@ public class TaskApplicationTests {
 	public void testTimeStampApp() throws Exception {
 		final String TEST_DATE_DOTS = ".......";
 		final String CREATE_TASK_MESSAGE = "Creating: TaskExecution{executionId=";
-		final String UPDATE_TASK_MESSAGE = "Updating: TaskExecution with executionId=1 with the following";
-		String[] args = { "--format=yyyy" + TEST_DATE_DOTS,
-			"--spring.cloud.task.closecontext.enable=false"};
+		// with multiple tests can't really track full executionId
+		final String UPDATE_TASK_MESSAGE = "Updating: TaskExecution with executionId=";
+		String[] args = { "--format=yyyy" + TEST_DATE_DOTS, "--spring.cloud.task.closecontext.enable=false" };
 
-		ConfigurableApplicationContext applicationContext = SpringApplication.run(TaskApplication.class, args);
-
-		TaskExplorer taskExplorer = applicationContext.getBean(TaskExplorer.class);
-
-		assertEquals(0, (int) taskExplorer.findTaskExecutionsByName("timestamp", new PageRequest(0, 10)).getContent().get(0).getExitCode());
+		assertEquals(0, SpringApplication.exit(SpringApplication
+				.run(TaskApplication.class, args)));
 
 		String output = this.outputCapture.toString();
 		assertTrue("Unable to find the timestamp: " + output,
 				output.contains(TEST_DATE_DOTS));
+		assertTrue("Test results do not show create task message: " + output,
+				output.contains(CREATE_TASK_MESSAGE));
+		assertTrue("Test results do not show success message: " + output,
+				output.contains(UPDATE_TASK_MESSAGE));
+	}
+
+	@Test
+	public void testTimeStampAppRepeat() throws Exception {
+		final String TEST_SLEEP = "Sleeping";
+		final String CREATE_TASK_MESSAGE = "Creating: TaskExecution{executionId=";
+		// with multiple tests can't really track full executionId
+		final String UPDATE_TASK_MESSAGE = "Updating: TaskExecution with executionId=";
+		String[] args = { "--repeat=3", "--spring.cloud.task.closecontext.enable=false" };
+
+		assertEquals(0, SpringApplication.exit(SpringApplication
+				.run(TaskApplication.class, args)));
+
+		String output = this.outputCapture.toString();
+		assertTrue("Unable to find the sleep message: " + output,
+				output.contains(TEST_SLEEP));
 		assertTrue("Test results do not show create task message: " + output,
 				output.contains(CREATE_TASK_MESSAGE));
 		assertTrue("Test results do not show success message: " + output,

--- a/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TimestampTaskPropertiesTests.java
+++ b/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TimestampTaskPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ public class TimestampTaskPropertiesTests {
 		TimestampTaskProperties properties = context.getBean(TimestampTaskProperties.class);
 		assertEquals("result does not match default format.", "yyyy-MM-dd HH:mm:ss.SSS",
 				properties.getFormat());
+		context.close();
 	}
 
 	@Test
@@ -59,6 +60,31 @@ public class TimestampTaskPropertiesTests {
 		properties.setFormat(FORMAT);
 		assertEquals("result does not match established format.", FORMAT,
 				properties.getFormat());
+		context.close();
+	}
+
+	@Test
+	public void testRepeatDefault() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.register(Conf.class);
+		context.refresh();
+		TimestampTaskProperties properties = context.getBean(TimestampTaskProperties.class);
+		assertEquals("result does not match default format.", 1,
+				properties.getRepeat());
+		context.close();
+	}
+
+	@Test
+	public void testRepeatSet() {
+		final int REPEAT = 1;
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.register(Conf.class);
+		context.refresh();
+		TimestampTaskProperties properties = context.getBean(TimestampTaskProperties.class);
+		properties.setRepeat(REPEAT);
+		assertEquals("result does not match established format.", REPEAT,
+				properties.getRepeat());
+		context.close();
 	}
 
 	@Configuration


### PR DESCRIPTION
- New 'repeat' option which sleeps 1 sec and
  allows to keep task alive for extended time.
- Polish tests.
- Fix other broken tests related to other changes.
- Fixes #31
