### PR TITLE
Remove mysql config from timestamp

### DIFF
--- a/timestamp/src/main/resources/application.properties
+++ b/timestamp/src/main/resources/application.properties
@@ -1,7 +1,1 @@
-spring.datasource.driverClassName=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/learning_spring_batch
-spring.datasource.username=root
-spring.datasource.password=p@ssw0rd
-spring.datasource.platform=mysql
-spring.datasource.continueOnError=false
 spring.application.name=timestamp


### PR DESCRIPTION
- Removing default mysql datasource configs
  from `application.properties` which would
  always fail as mysql libs are not bundled and
  actually disables embedded h2 configuration to
  take place.
- Fixes #34
