### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-task-modules-common-configuration/src/main/java/org/springframework/cloud/task/sparkapp/common/SparkAppCommonTaskProperties.java
+++ b/common/spring-cloud-task-modules-common-configuration/src/main/java/org/springframework/cloud/task/sparkapp/common/SparkAppCommonTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-task-modules-common-configuration/src/main/java/org/springframework/cloud/task/sqoop/common/SqoopCommonRunnerUtils.java
+++ b/common/spring-cloud-task-modules-common-configuration/src/main/java/org/springframework/cloud/task/sqoop/common/SqoopCommonRunnerUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-task-modules-common-configuration/src/main/java/org/springframework/cloud/task/sqoop/common/SqoopCommonTaskProperties.java
+++ b/common/spring-cloud-task-modules-common-configuration/src/main/java/org/springframework/cloud/task/sqoop/common/SqoopCommonTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-task-modules-common-configuration/src/test/java/org/springframework/cloud/task/sparkapp/common/SparkAppCommonTaskPropertiesTests.java
+++ b/common/spring-cloud-task-modules-common-configuration/src/test/java/org/springframework/cloud/task/sparkapp/common/SparkAppCommonTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-task-modules-common-configuration/src/test/java/org/springframework/cloud/task/sqoop/common/SqoopCommonTaskPropertiesTests.java
+++ b/common/spring-cloud-task-modules-common-configuration/src/test/java/org/springframework/cloud/task/sqoop/common/SqoopCommonTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/spring-cloud-task-modules-common-configuration/src/test/java/org/springframework/cloud/task/sqoop/common/SqoopToolDatabaseConfiguration.java
+++ b/common/spring-cloud-task-modules-common-configuration/src/test/java/org/springframework/cloud/task/sqoop/common/SqoopToolDatabaseConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/settings.xml
+++ b/settings.xml
@@ -7,7 +7,7 @@
   ~  * you may not use this file except in compliance with the License.
   ~  * You may obtain a copy of the License at
   ~  *
-  ~  *      http://www.apache.org/licenses/LICENSE-2.0
+  ~  *      https://www.apache.org/licenses/LICENSE-2.0
   ~  *
   ~  * Unless required by applicable law or agreed to in writing, software
   ~  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-client/src/main/java/org/springframework/cloud/task/sparkapp/client/SparkAppClientRunner.java
+++ b/sparkapp-client/src/main/java/org/springframework/cloud/task/sparkapp/client/SparkAppClientRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-client/src/main/java/org/springframework/cloud/task/sparkapp/client/SparkAppClientTaskApplication.java
+++ b/sparkapp-client/src/main/java/org/springframework/cloud/task/sparkapp/client/SparkAppClientTaskApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-client/src/test/java/org/apache/spark/examples/JavaSparkPi.java
+++ b/sparkapp-client/src/test/java/org/apache/spark/examples/JavaSparkPi.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *    https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-client/src/test/java/org/springframework/cloud/task/sparkapp/client/SparkAppClientTaskApplicationTests.java
+++ b/sparkapp-client/src/test/java/org/springframework/cloud/task/sparkapp/client/SparkAppClientTaskApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-cluster/src/main/java/org/springframework/cloud/task/sparkapp/cluster/SparkAppClusterRunner.java
+++ b/sparkapp-cluster/src/main/java/org/springframework/cloud/task/sparkapp/cluster/SparkAppClusterRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-cluster/src/main/java/org/springframework/cloud/task/sparkapp/cluster/SparkAppClusterTaskApplication.java
+++ b/sparkapp-cluster/src/main/java/org/springframework/cloud/task/sparkapp/cluster/SparkAppClusterTaskApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-cluster/src/main/java/org/springframework/cloud/task/sparkapp/cluster/SparkAppClusterTaskProperties.java
+++ b/sparkapp-cluster/src/main/java/org/springframework/cloud/task/sparkapp/cluster/SparkAppClusterTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-cluster/src/test/java/org/springframework/cloud/task/sparkapp/cluster/SparkAppClusterTaskPropertiesTests.java
+++ b/sparkapp-cluster/src/test/java/org/springframework/cloud/task/sparkapp/cluster/SparkAppClusterTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-yarn/src/main/java/org/springframework/cloud/task/sparkapp/yarn/SparkAppYarnRunner.java
+++ b/sparkapp-yarn/src/main/java/org/springframework/cloud/task/sparkapp/yarn/SparkAppYarnRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-yarn/src/main/java/org/springframework/cloud/task/sparkapp/yarn/SparkAppYarnTaskApplication.java
+++ b/sparkapp-yarn/src/main/java/org/springframework/cloud/task/sparkapp/yarn/SparkAppYarnTaskApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-yarn/src/main/java/org/springframework/cloud/task/sparkapp/yarn/SparkAppYarnTaskProperties.java
+++ b/sparkapp-yarn/src/main/java/org/springframework/cloud/task/sparkapp/yarn/SparkAppYarnTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sparkapp-yarn/src/test/java/org/springframework/cloud/task/sparkapp/yarn/SparkAppYarnTaskPropertiesTests.java
+++ b/sparkapp-yarn/src/test/java/org/springframework/cloud/task/sparkapp/yarn/SparkAppYarnTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-job/src/main/java/org/springframework/cloud/task/sqoop/job/SqoopJobRunner.java
+++ b/sqoop-job/src/main/java/org/springframework/cloud/task/sqoop/job/SqoopJobRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-job/src/main/java/org/springframework/cloud/task/sqoop/job/SqoopJobTaskApplication.java
+++ b/sqoop-job/src/main/java/org/springframework/cloud/task/sqoop/job/SqoopJobTaskApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-job/src/main/java/org/springframework/cloud/task/sqoop/job/SqoopJobTaskProperties.java
+++ b/sqoop-job/src/main/java/org/springframework/cloud/task/sqoop/job/SqoopJobTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-job/src/test/java/org/springframework/cloud/task/sqoop/job/SqoopToolJobApplicationTests.java
+++ b/sqoop-job/src/test/java/org/springframework/cloud/task/sqoop/job/SqoopToolJobApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-job/src/test/java/org/springframework/cloud/task/sqoop/job/SqoopToolJobPropertiesTests.java
+++ b/sqoop-job/src/test/java/org/springframework/cloud/task/sqoop/job/SqoopToolJobPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-tool/src/main/java/org/springframework/cloud/task/sqoop/tool/SqoopToolRunner.java
+++ b/sqoop-tool/src/main/java/org/springframework/cloud/task/sqoop/tool/SqoopToolRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-tool/src/main/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskApplication.java
+++ b/sqoop-tool/src/main/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-tool/src/main/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskProperties.java
+++ b/sqoop-tool/src/main/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-tool/src/test/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskApplicationTests.java
+++ b/sqoop-tool/src/test/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sqoop-tool/src/test/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskPropertiesTests.java
+++ b/sqoop-tool/src/test/java/org/springframework/cloud/task/sqoop/tool/SqoopToolTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TaskApplication.java
+++ b/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TaskApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TimestampTaskProperties.java
+++ b/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TimestampTaskProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TaskApplicationTests.java
+++ b/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TaskApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TimestampTaskPropertiesTests.java
+++ b/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TimestampTaskPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/timestamp/src/test/resources/application.properties
+++ b/timestamp/src/test/resources/application.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 35 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).